### PR TITLE
raised esdoc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "main": "Gruntfile.js",
 
     "dependencies": {
-        "esdoc": "0.1.4"
+        "esdoc": "~0.4.0"
     },
 
     "devDependencies": {


### PR DESCRIPTION
When using your plugin i ran into the issue: 

`Warning: Cannot read property 'type' of null Use --force to continue.`

Using the latest version of esdoc solves this issue. Would you please be so kind to accept my pull and release to NPM?
