### PR TITLE
Coverage Thresholds and Failing

### DIFF
--- a/tasks/esdoc.js
+++ b/tasks/esdoc.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
                     grunt.log[fileFail ? `warn` : `ok`](`Files: ${amount}/${total}`);
 
                     if (config.failOnCoverage && (percentFail || fileFail)) {
-                        grunt.fail.warn("Coverage results don't meet the treshold.")
+                        grunt.fail.warn(`Coverage results don't meet the treshold.`)
                     }
                 }
 

--- a/tasks/esdoc.js
+++ b/tasks/esdoc.js
@@ -17,7 +17,10 @@ module.exports = function (grunt) {
 
         // Merge task-specific and/or target-specific options with these defaults.
         var options = this.options({
-            coverage: true
+            coverage: true,
+            failOnCoverage: false,
+            percentThreshold: 0,
+            fileThreshold: 0
         });
 
         var config = {};
@@ -64,11 +67,18 @@ module.exports = function (grunt) {
                 if (m = ln.match(/^Coverage:\s*(\d{1,3}(?:\.?\d{0,2}))%\s*\((\d+)\/(\d+)\)$/)) {
                     const percent = parseFloat(m[1]),
                         amount = parseInt(m[2]),
-                        total = parseInt(m[3]);
+                        total = parseInt(m[3]),
+                        percentFail = percent < config.percentThreshold,
+                        fileFail = (amount / total) < config.fileThreshold;
 
-                    grunt.log[percent < 100 ? `warn` : `ok`](`Coverage: ${percent}%`);
-                    grunt.log[amount < total ? `warn` : `ok`](`Files: ${amount}/${total}`);
+                    grunt.log[percentFail ? `warn` : `ok`](`Coverage: ${percent}%`);
+                    grunt.log[fileFail ? `warn` : `ok`](`Files: ${amount}/${total}`);
+
+                    if (config.failOnCoverage && (percentFail || fileFail)) {
+                        grunt.fail.warn("Coverage results don't meet the treshold.")
+                    }
                 }
+
                 return m;
             });
 

--- a/tasks/esdoc.js
+++ b/tasks/esdoc.js
@@ -56,16 +56,15 @@ module.exports = function (grunt) {
 
             // Pass the config to ESDoc to publish the documentation
             esdoc.generate(config, publisher);
-
             // If coverage is configured then parse out the coverage values
             // This goes in reverse (as coverage is near the end) and uses
             // some to iterate over the reversed lines until one matching
             // the regex is found
             lines.reverse().some((ln, m) => {
-                if (m = ln.match(/^Coverage:\s*(\d{1,3}(?:\.\d{0,2}))%\s*\((\d+)\/(\d+)\)$/)) {
-                    const percent = parseFloat(m[1]);
-                    const amount = parseInt(m[2]);
-                    const total = parseInt(m[3]);
+                if (m = ln.match(/^Coverage:\s*(\d{1,3}(?:\.?\d{0,2}))%\s*\((\d+)\/(\d+)\)$/)) {
+                    const percent = parseFloat(m[1]),
+                        amount = parseInt(m[2]),
+                        total = parseInt(m[3]);
 
                     grunt.log[percent < 100 ? `warn` : `ok`](`Coverage: ${percent}%`);
                     grunt.log[amount < total ? `warn` : `ok`](`Files: ${amount}/${total}`);

--- a/tasks/esdoc.js
+++ b/tasks/esdoc.js
@@ -69,7 +69,7 @@ module.exports = function (grunt) {
                         amount = parseInt(m[2]),
                         total = parseInt(m[3]),
                         percentFail = percent < config.percentThreshold,
-                        fileFail = (amount / total) < config.fileThreshold;
+                        fileFail = (amount / total * 100) < config.fileThreshold;
 
                     grunt.log[percentFail ? `warn` : `ok`](`Coverage: ${percent}%`);
                     grunt.log[fileFail ? `warn` : `ok`](`Files: ${amount}/${total}`);

--- a/test/esdoc.json
+++ b/test/esdoc.json
@@ -1,4 +1,5 @@
 {
     "source": "./test/src",
-    "destination": "./test/docs"
+    "destination": "./test/docs",
+    "coverage": true
 }

--- a/test/esdoc.json
+++ b/test/esdoc.json
@@ -1,5 +1,8 @@
 {
     "source": "./test/src",
     "destination": "./test/docs",
-    "coverage": true
+    "coverage": true,
+    "failOnCoverage": true,
+    "percentThreshold": 90,
+    "fileThreshold": 50
 }


### PR DESCRIPTION
This PR includes changes that allow the user to pass in thresholds for coverage, and (optionally) fail if those thresholds aren't met. 

Also included (commit b8b8d58) is a fix for coverage percentages that don't have a decimal point.
