### PR TITLE
Updated ESDoc to 0.5.x.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
         "url": "https://github.com/cleversoap/grunt-esdoc.git"
     },
     "dependencies": {
-        "esdoc": "^0.4.7"
+        "esdoc": "0.5.x"
     },
     "devDependencies": {
-        "grunt": "^1.0.1"
+        "grunt": "1.0.x"
     }
 }


### PR DESCRIPTION
Hi,

I changed the version of the ```esdoc``` dependency to 0.5.x. There are no breaking changes in this version of ESDoc. I also adjusted the dev dependency ```grunt``` to match the new version style.

I think it's much easier to understand the semantics of using x instead of ^ or ~. If you prefer the old style, I'll change it back. Just say the word!


