### PR TITLE
Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/grunt-esdoc.svg)](https://badge.fury.io/js/grunt-esdoc)
 [![Dependencies](https://david-dm.org/cleversoap/grunt-esdoc.svg?branch=master)](https://david-dm.org/cleversoap/grunt-esdoc)
 
-A Grunt plugin for the ES6 documentation tool [ESDoc](https://esdoc.org/).
+A Grunt plugin for the ES2015+ documentation tool [ESDoc](https://esdoc.org/).
 
 
 ## Getting Started
@@ -54,7 +54,8 @@ grunt.initConfig({
 		compile: {
 			options: {
 				source: "src",
-				destination: "docs"
+				destination: "docs",
+				plugins: [{"name": "esdoc-standard-plugin"}]
 			}
 		}
 	}
@@ -76,7 +77,7 @@ grunt.registerTask("default", ["lint", "test", "esdoc"]);
 
 ## Configuration
 
-All [ESDoc config properties](https://esdoc.org/manual/configuration/config.html) are allowed under ```options```.
+All [ESDoc options](https://esdoc.org/manual/config.html) defined under ```options``` are passed to ESDoc:
 
 ```javascript
 grunt.initConfig({
@@ -85,56 +86,19 @@ grunt.initConfig({
 			options: {
 				source: "./path/to/src",
 				destination: "./path/to/esdoc/output",
-				includes: ["\\.(js|es6)$"],
-				excludes: ["\\.config\\.(js|es6)$"],
-				access: ["public", "protected"],
-				autoPrivate: true,
-				unexportIdentifier: false,
-				undocumentIdentifier: true,
-				builtinExternal: true,
-				importPathPrefix: "",
-				index: "./README.md",
-				package: "./package.json",
-				coverage: true,
-				test: {
-					type: "mocha",
-					source: "./test/src",
-					includes: ["Test\\.(js|es6)$"],
-					excludes: ["\\.config\\.(js|es6)$"]
-				}
-				title: "My Software Name",
-				styles: ["./path/to/style.css"],
-				scripts: ["./path/to/script.js"],
-				plugins: [{
-					name: "plugin-name-or-file-path",
-					option: null
-				}],
-				manual: {
-					globalIndex: true,
-					index: "./manual/index.md",
-					asset: "./manual/asset",
-					overview: ["./manual/overview.md"],
-					design: ["./manual/design.md"],
-					installation: ["./manual/installation.md"],
-					usage: ["./manual/usage.md"],
-					tutorial: ["./manual/tutorial.md"],
-					configuration: ["./manual/configuration.md"],
-					example: ["./manual/example.md"],
-					advanced: ["./manual/advanced.md"],
-					faq: ["./manual/faq.md"],
-					changelog: ["./CHANGELOG.md"]
-				},
-				lint: true,
-				experimentalProposal: {
-					classProperties: true,
-					objectRestSpread: true,
-					decorators: true,
-					doExpressions: true,
-					functionBind: true,
-					asyncGenerators: true,
-					exportExtensions: true,
-					dynamicImport: true
-				}
+				plugins: [
+					{
+						name: "esdoc-standard-plugin",
+						option: {
+							test: {
+								source: "./test/",
+								interfaces: ["describe", "it", "context", "suite", "test"],
+								includes: ["(spec|Spec|test|Test)\\.js$"],
+								excludes: ["\\.config\\.js$"]
+							}
+						}
+					}
+				]
 			}
 		}
 	}
@@ -148,7 +112,8 @@ Alternatively, you can specify a ```config``` path to a file containing the conf
 ```javascript
 {
 	"source": "src",
-	"destination": "docs"
+	"destination": "docs",
+	"plugins": [{"name": "esdoc-standard-plugin"}]
 }
 ```
 
@@ -174,13 +139,14 @@ Any contribution is welcome! Please check the [issues](https://github.com/clever
 
 ## Release History
 
- * _0.0.1_ First Release - using esdoc 0.1.4 and directly passing through options using the default publisher
- * _0.0.2_ Using esdoc ~0.4.0 and updated the package metadata with relevant links
- * _0.0.3_ Upgrade to at least node 4.0.0, upgrade to esdoc 0.4.7, cleaned up output to only show coverage by default
- * _0.0.4_ Will now parse float percentages of coverage
+ * _0.0.1_ First Release - using esdoc 0.1.4 and directly passing through options using the default publisher.
+ * _0.0.2_ Using esdoc ~0.4.0 and updated the package metadata with relevant links.
+ * _0.0.3_ Upgrade to at least node 4.0.0, upgrade to esdoc 0.4.7, cleaned up output to only show coverage by default.
+ * _0.0.4_ Will now parse float percentages of coverage.
+ * _1.0.0_ Most ESDoc features are now plugins. Check [here](https://esdoc.org/manual/migration.html) for more information.
 
 
 ## License
 
-Copyright (c) 2016 Cleversoap
+Copyright © 2016 Cleversoap  
 Licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ grunt.loadNpmTasks("grunt-esdoc");
 
 ## Usage
 
-##### my-class.js
+##### MyClass.js
 
 ```javascript
 /**

--- a/README.md
+++ b/README.md
@@ -1,113 +1,186 @@
 # grunt-esdoc
 
-Grunt plugin for the ES6 documentation tool [ESDoc](https://esdoc.org/)
+[![npm version](https://badge.fury.io/js/grunt-esdoc.svg)](https://badge.fury.io/js/grunt-esdoc)
+[![Dependencies](https://david-dm.org/cleversoap/grunt-esdoc.svg?branch=master)](https://david-dm.org/cleversoap/grunt-esdoc)
 
-## Install
+A Grunt plugin for the ES6 documentation tool [ESDoc](https://esdoc.org/).
 
-```bash
+
+## Getting Started
+
+This plugin requires Grunt >= 0.4.0
+
+If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) 
+guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. 
+Once you're familiar with that process, you may install this plugin with this command:
+
+```sh
 npm install grunt-esdoc --save-dev
+``` 
+
+Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
+
+```js
+grunt.loadNpmTasks("grunt-esdoc");
 ```
 
-## Documentation
 
-### Configuration
+## Usage
 
-Configure the plugin in your project's Gruntfile.js.
+##### my-class.js
 
-First, add the `esdoc` entry to the options of the `initConfig` method :
+```javascript
+/**
+ * Description of MyClass.
+ */
+export default class MyClass {
+
+	/**
+	 * Description of method.
+	 *
+	 * @param {Number} param - Description of param.
+	 * @return {Number} Description of the return value.
+	 */
+	method(param) {}
+
+}
+```
+
+##### Gruntfile.js
 
 ```javascript
 grunt.initConfig({
-    esdoc : {
-        dist : {
-            options: {
-                source: './src',
-                destination: './doc'
-            }
-        }
-    }
-});
-```
-Then, load the plugin
-
-```javascript
-grunt.loadNpmTasks('grunt-jsdoc');
-```
-
-[All ESDoc config properties are allowed under options](https://esdoc.org/config.html).
-
-```javascript
-grunt.initConfig({
-    esdoc : {
-        dist : {
-            options: {
-              source: './path/to/src',
-              destination: './path/to/esdoc',
-              includes: ['\\.(js|es6)$'],
-              excludes: ['\\.config\\.(js|es6)$'],
-              access: ['public', 'protected'],
-              autoPrivate: true,
-              unexportIdentifier: false,
-              undocumentIdentifier: true,
-              builtinExternal: true,
-              importPathPrefix: '',
-              index: './README.md',
-              package: './package.json',
-              coverage: true,
-              test: {
-                type: 'mocha',
-                source: './test/src',
-                includes: ['Test\\.(js|es6)$'],
-                excludes: ['\\.config\\.(js|es6)$']
-              }
-              title: 'My Software Name',
-              styles: ['./path/to/style.css'],
-              scripts: ['./path/to/script.js']
-            }
-        }
-    }
+	esdoc: {
+		compile: {
+			options: {
+				source: "src",
+				destination: "docs"
+			}
+		}
+	}
 });
 ```
 
-Alternatively, you can pass
-a `config` option instead that is a path to a file containing the configuration options for ESDoc.
-
-```javascript
-grunt.initConfig({
-    esdoc : {
-        dist : {
-            options: {
-                config: 'esdoc.json'
-            }
-        }
-    }
-});
-```
-
-### Build
-
-To generate the documentation, you need to call the `esdoc` task :
+Call the ```esdoc``` task to generate the documentation. Use ```--verbose``` to see all ESDoc log messages.
 
 ```bash
-$> grunt esdoc
+grunt esdoc --verbose
 ```
 
-or integrate it to your build sequence :
+You may also integrate the task into your build sequence:
 
 ```javascript
-grunt.registerTask('default', ['lint', 'test', 'esdoc']);
+grunt.registerTask("default", ["lint", "test", "esdoc"]);
 ```
+
+
+## Configuration
+
+All [ESDoc config properties](https://esdoc.org/manual/configuration/config.html) are allowed under ```options```.
+
+```javascript
+grunt.initConfig({
+	esdoc: {
+		compile: {
+			options: {
+				source: "./path/to/src",
+				destination: "./path/to/esdoc/output",
+				includes: ["\\.(js|es6)$"],
+				excludes: ["\\.config\\.(js|es6)$"],
+				access: ["public", "protected"],
+				autoPrivate: true,
+				unexportIdentifier: false,
+				undocumentIdentifier: true,
+				builtinExternal: true,
+				importPathPrefix: "",
+				index: "./README.md",
+				package: "./package.json",
+				coverage: true,
+				test: {
+					type: "mocha",
+					source: "./test/src",
+					includes: ["Test\\.(js|es6)$"],
+					excludes: ["\\.config\\.(js|es6)$"]
+				}
+				title: "My Software Name",
+				styles: ["./path/to/style.css"],
+				scripts: ["./path/to/script.js"],
+				plugins: [{
+					name: "plugin-name-or-file-path",
+					option: null
+				}],
+				manual: {
+					globalIndex: true,
+					index: "./manual/index.md",
+					asset: "./manual/asset",
+					overview: ["./manual/overview.md"],
+					design: ["./manual/design.md"],
+					installation: ["./manual/installation.md"],
+					usage: ["./manual/usage.md"],
+					tutorial: ["./manual/tutorial.md"],
+					configuration: ["./manual/configuration.md"],
+					example: ["./manual/example.md"],
+					advanced: ["./manual/advanced.md"],
+					faq: ["./manual/faq.md"],
+					changelog: ["./CHANGELOG.md"]
+				},
+				lint: true,
+				experimentalProposal: {
+					classProperties: true,
+					objectRestSpread: true,
+					decorators: true,
+					doExpressions: true,
+					functionBind: true,
+					asyncGenerators: true,
+					exportExtensions: true,
+					dynamicImport: true
+				}
+			}
+		}
+	}
+});
+```
+
+Alternatively, you can specify a ```config``` path to a file containing the configuration options for ESDoc.
+
+##### esdoc.json
+
+```javascript
+{
+	"source": "src",
+	"destination": "docs"
+}
+```
+
+##### Gruntfile.js
+
+```javascript
+grunt.initConfig({
+	esdoc: {
+		compile: {
+			options: {
+				config: "esdoc.json"
+			}
+		}
+	}
+});
+```
+
 
 ## Contributing
 
 Any contribution is welcome! Please check the [issues](https://github.com/cleversoap/grunt-esdoc/issues).
 
+
 ## Release History
+
  * _0.0.1_ First Release - using esdoc 0.1.4 and directly passing through options using the default publisher
  * _0.0.2_ Using esdoc ~0.4.0 and updated the package metadata with relevant links
  * _0.0.3_ Upgrade to at least node 4.0.0, upgrade to esdoc 0.4.7, cleaned up output to only show coverage by default
  * _0.0.4_ Will now parse float percentages of coverage
 
+
 ## License
+
 Copyright (c) 2016 Cleversoap
 Licensed under the MIT license.


### PR DESCRIPTION
Hello,

I've made the following changes to the README file:
 - added npm version badge
 - added dependency status badge
 - added ```Getting Started``` section
 - adjusted usage examples
 - updated configuration options
 - added documentation for the ```--verbose``` cli flag
 - fixed a dead link

It looks like [this](https://github.com/vanruesc/grunt-esdoc/blob/patch02/README.md).

These are only suggestions, feel free to disagree!